### PR TITLE
Fixed `toByteString` in Data.Ewkb to allow SridType to be specified.

### DIFF
--- a/src/Data/Ewkb.hs
+++ b/src/Data/Ewkb.hs
@@ -34,7 +34,8 @@ parseByteString byteString =
 parseHexByteString :: Hex.Hex -> Either String Geospatial.GeospatialGeometry
 parseHexByteString = Hex.safeConvert parseByteString
 
-toByteString :: Endian.EndianType -> Geospatial.GeospatialGeometry -> LazyByteString.ByteString
-toByteString endianType =
+toByteString :: Endian.EndianType -> EwkbGeometry.SridType -> Geospatial.GeospatialGeometry -> LazyByteString.ByteString
+toByteString endianType sridType =
   ByteStringBuilder.toLazyByteString . WkbGeospatial.builderGeospatialGeometry
-    EwkbGeometry.builderWkbGeom endianType
+    mkBuilder endianType
+  where mkBuilder eType gType = EwkbGeometry.builderEwkbGeom eType (EwkbGeometry.EwkbGeom gType sridType)


### PR DESCRIPTION
Currently the implementation of `toByteString` in Data.Ewkb is exactly
the same as that in Data.Wkb. This causes postgis (via persistent-postgresql)
to reject the serialized EWKB as it doesn't contain SRID.

Not sure if I get the library's intention right. Please close this PR if I'm wrong.