### PR TITLE
bump stackage lts to 18.5

### DIFF
--- a/src/Data/Hex.hs
+++ b/src/Data/Hex.hs
@@ -8,18 +8,12 @@ import qualified Data.ByteString.Base16 as ByteStringBase16
 import qualified Data.ByteString.Char8  as ByteStringChar8
 import qualified Data.ByteString.Lazy   as LazyByteString
 import qualified Data.Geospatial        as Geospatial
-import           Data.Monoid            ((<>))
 
 newtype Hex = Hex ByteString.ByteString
 
 safeConvert :: (LazyByteString.ByteString -> Either String Geospatial.GeospatialGeometry) -> Hex -> Either String Geospatial.GeospatialGeometry
 safeConvert f (Hex byteString) =
-  let
-    (decoded, rest) = ByteStringBase16.decode byteString
-  in
-    if ByteString.null rest then
-      f $ LazyByteString.fromStrict decoded
-    else
-      Left ("Invalid hex representation: " <> ByteStringChar8.unpack byteString)
-
+    case ByteStringBase16.decode byteString of
+         Left  _       -> Left $ "Invalid hex representation: " <> ByteStringChar8.unpack byteString
+         Right decoded -> f    $ LazyByteString.fromStrict decoded
 

--- a/src/Data/Internal/Ewkb/Geometry.hs
+++ b/src/Data/Internal/Ewkb/Geometry.hs
@@ -11,7 +11,6 @@ import qualified Control.Monad              as Monad
 import qualified Data.Binary.Get            as BinaryGet
 import           Data.Bits                  ((.&.), (.|.))
 import qualified Data.ByteString.Builder    as ByteStringBuilder
-import           Data.Monoid                ((<>))
 import qualified Data.Word                  as Word
 
 import qualified Data.Internal.Wkb.Endian   as Endian

--- a/src/Data/Internal/Wkb/GeometryCollection.hs
+++ b/src/Data/Internal/Wkb/GeometryCollection.hs
@@ -9,7 +9,6 @@ import qualified Data.Binary.Get            as BinaryGet
 import qualified Data.ByteString.Builder    as ByteStringBuilder
 import qualified Data.Foldable              as Foldable
 import qualified Data.Geospatial            as Geospatial
-import           Data.Monoid                ((<>))
 import qualified Data.Sequence              as Sequence
 
 import qualified Data.Internal.Wkb.Endian   as Endian

--- a/src/Data/Internal/Wkb/Line.hs
+++ b/src/Data/Internal/Wkb/Line.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString.Builder              as ByteStringBuilder
 import qualified Data.Foldable                        as Foldable
 import qualified Data.Geospatial                      as Geospatial
 import qualified Data.LineString                      as LineString
-import           Data.Monoid                          ((<>))
 import qualified Data.Sequence                        as Sequence
 
 

--- a/src/Data/Internal/Wkb/Point.hs
+++ b/src/Data/Internal/Wkb/Point.hs
@@ -14,7 +14,6 @@ import qualified Data.Binary.Get                      as BinaryGet
 import qualified Data.ByteString.Builder              as ByteStringBuilder
 import qualified Data.Foldable                        as Foldable
 import qualified Data.Geospatial                      as Geospatial
-import           Data.Monoid                          ((<>))
 import qualified Data.Monoid                          as Monoid
 import qualified Data.Sequence                        as Sequence
 import qualified Data.Word                            as Word

--- a/src/Data/Internal/Wkb/Polygon.hs
+++ b/src/Data/Internal/Wkb/Polygon.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString.Builder              as ByteStringBuilder
 import qualified Data.Foldable                        as Foldable
 import qualified Data.Geospatial                      as Geospatial
 import qualified Data.LinearRing                      as LinearRing
-import           Data.Monoid                          ((<>))
 import qualified Data.Sequence                        as Sequence
 
 import qualified Data.Internal.Wkb.Endian             as Endian

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.26
+resolver: lts-18.5
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -41,7 +41,6 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- geojson-4.0.1
 - hw-hspec-hedgehog-0.1.0.4
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: geojson-4.0.1@sha256:276de5cb2aa3e07179a8d42c184b1a4e52d2c8d23cf2eb989ecfa6adbe726227,4234
-    pantry-tree:
-      size: 2429
-      sha256: ef88e984e076f60d21ca0677a0f011abf40abecd5562e894575db2098ef49c98
-  original:
-    hackage: geojson-4.0.1
-- completed:
     hackage: hw-hspec-hedgehog-0.1.0.4@sha256:f856bb4868934e9a1f110da8e88c9052ebe94dc7a7016d44b24bb08322b900ca,1547
     pantry-tree:
       size: 412
@@ -20,7 +13,7 @@ packages:
     hackage: hw-hspec-hedgehog-0.1.0.4
 snapshots:
 - completed:
-    size: 509471
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/12/26.yaml
-    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
-  original: lts-12.26
+    size: 585817
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/5.yaml
+    sha256: 22d24d0dacad9c1450b9a174c28d203f9bb482a2a8da9710a2f2a9f4afee2887
+  original: lts-18.5


### PR DESCRIPTION
The deps in package.yaml should also have upper bounds to properly conform to the PVP (and avoid spurious compilation errors).